### PR TITLE
Add health check endpoint and configure server port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+- mvn spring-boot:run (기본 포트가 9000이 되도록 위 설정 반영)

--- a/src/main/java/com/example/embed_chatbot/HealthCheckController.java
+++ b/src/main/java/com/example/embed_chatbot/HealthCheckController.java
@@ -1,0 +1,13 @@
+package com.example.embed_chatbot;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheckController {
+
+    @GetMapping("/health")
+    public String health() {
+        return "OK";
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,2 @@
+server:
+  port: 9000


### PR DESCRIPTION
## Summary
- configure the Spring Boot server to listen on port 9000 via `application.yml`
- add a simple `/health` endpoint that returns `OK`
- document how to run the application with `mvn spring-boot:run`

## Testing
- `./mvnw -q -DskipTests package` *(fails: unable to download Maven distribution because of restricted network access)*

------
https://chatgpt.com/codex/tasks/task_e_68d43607bf68832fbbd0adcaa12429ac