### PR TITLE
Implement chat API MVP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 - mvn spring-boot:run (기본 포트가 9000이 되도록 위 설정 반영)
 - 로컬 개발 시 http://localhost:8000, http://127.0.0.1:8000 도메인에서 CORS 허용
+
+### API 테스트 예시
+
+```
+curl -X POST "http://localhost:9000/v1/chat" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "botId": "sample-bot",
+    "message": "Hello there!",
+    "sessionId": "demo-session"
+  }'
+```

--- a/src/main/java/com/example/embedchatbot/EmbedChatbotApplication.java
+++ b/src/main/java/com/example/embedchatbot/EmbedChatbotApplication.java
@@ -1,0 +1,12 @@
+package com.example.embedchatbot;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class EmbedChatbotApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(EmbedChatbotApplication.class, args);
+    }
+}

--- a/src/main/java/com/example/embedchatbot/chat/ChatController.java
+++ b/src/main/java/com/example/embedchatbot/chat/ChatController.java
@@ -1,0 +1,28 @@
+package com.example.embedchatbot.chat;
+
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/chat")
+public class ChatController {
+
+    private final ChatService chatService;
+
+    public ChatController(ChatService chatService) {
+        this.chatService = chatService;
+    }
+
+    @PostMapping
+    public ResponseEntity<ChatResponse> chat(@Valid @RequestBody ChatRequest request) {
+        long startTime = System.nanoTime();
+        ChatResult result = chatService.chat(request);
+        long latencyMs = Math.round((System.nanoTime() - startTime) / 1_000_000.0);
+        ChatResponse response = new ChatResponse(result.answer(), result.sessionId(), result.usage(), latencyMs);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/embedchatbot/chat/ChatRequest.java
+++ b/src/main/java/com/example/embedchatbot/chat/ChatRequest.java
@@ -1,0 +1,53 @@
+package com.example.embedchatbot.chat;
+
+import jakarta.validation.constraints.NotBlank;
+
+import java.util.Map;
+
+public class ChatRequest {
+
+    @NotBlank
+    private String botId;
+
+    @NotBlank
+    private String message;
+
+    private String sessionId;
+
+    private Map<String, Object> meta;
+
+    public ChatRequest() {
+    }
+
+    public String getBotId() {
+        return botId;
+    }
+
+    public void setBotId(String botId) {
+        this.botId = botId;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public void setSessionId(String sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public Map<String, Object> getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Map<String, Object> meta) {
+        this.meta = meta;
+    }
+}

--- a/src/main/java/com/example/embedchatbot/chat/ChatResponse.java
+++ b/src/main/java/com/example/embedchatbot/chat/ChatResponse.java
@@ -1,0 +1,32 @@
+package com.example.embedchatbot.chat;
+
+public class ChatResponse {
+
+    private final String answer;
+    private final String sessionId;
+    private final ChatUsage usage;
+    private final long latencyMs;
+
+    public ChatResponse(String answer, String sessionId, ChatUsage usage, long latencyMs) {
+        this.answer = answer;
+        this.sessionId = sessionId;
+        this.usage = usage;
+        this.latencyMs = latencyMs;
+    }
+
+    public String getAnswer() {
+        return answer;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+
+    public ChatUsage getUsage() {
+        return usage;
+    }
+
+    public long getLatencyMs() {
+        return latencyMs;
+    }
+}

--- a/src/main/java/com/example/embedchatbot/chat/ChatResult.java
+++ b/src/main/java/com/example/embedchatbot/chat/ChatResult.java
@@ -1,0 +1,4 @@
+package com.example.embedchatbot.chat;
+
+public record ChatResult(String answer, String sessionId, ChatUsage usage) {
+}

--- a/src/main/java/com/example/embedchatbot/chat/ChatService.java
+++ b/src/main/java/com/example/embedchatbot/chat/ChatService.java
@@ -1,0 +1,35 @@
+package com.example.embedchatbot.chat;
+
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.UUID;
+
+@Service
+public class ChatService {
+
+    public ChatResult chat(ChatRequest request) {
+        String sessionId = resolveSessionId(request.getSessionId());
+        String answer = buildAnswer(request.getMessage());
+        ChatUsage usage = new ChatUsage(estimateTokens(request.getMessage()), estimateTokens(answer));
+        return new ChatResult(answer, sessionId, usage);
+    }
+
+    private String resolveSessionId(String sessionId) {
+        if (StringUtils.hasText(sessionId)) {
+            return sessionId;
+        }
+        return UUID.randomUUID().toString();
+    }
+
+    private String buildAnswer(String message) {
+        return "Echo: " + message;
+    }
+
+    private int estimateTokens(String text) {
+        if (!StringUtils.hasText(text)) {
+            return 0;
+        }
+        return text.length();
+    }
+}

--- a/src/main/java/com/example/embedchatbot/chat/ChatUsage.java
+++ b/src/main/java/com/example/embedchatbot/chat/ChatUsage.java
@@ -1,0 +1,4 @@
+package com.example.embedchatbot.chat;
+
+public record ChatUsage(int promptTokens, int completionTokens) {
+}

--- a/src/test/java/com/example/embedchatbot/chat/ChatControllerTest.java
+++ b/src/test/java/com/example/embedchatbot/chat/ChatControllerTest.java
@@ -1,0 +1,64 @@
+package com.example.embedchatbot.chat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ChatController.class)
+class ChatControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private ChatService chatService;
+
+    @DisplayName("POST /v1/chat returns chat response")
+    @Test
+    void chat_success() throws Exception {
+        ChatUsage usage = new ChatUsage(10, 12);
+        ChatResult result = new ChatResult("Echo: hello", "session-123", usage);
+        given(chatService.chat(any(ChatRequest.class))).willReturn(result);
+
+        ChatRequest request = new ChatRequest();
+        request.setBotId("bot-1");
+        request.setMessage("hello");
+
+        mockMvc.perform(post("/v1/chat")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.answer", is("Echo: hello")))
+                .andExpect(jsonPath("$.sessionId", is("session-123")))
+                .andExpect(jsonPath("$.usage.promptTokens", is(10)))
+                .andExpect(jsonPath("$.usage.completionTokens", is(12)))
+                .andExpect(jsonPath("$.latencyMs").exists());
+    }
+
+    @DisplayName("POST /v1/chat validates required fields")
+    @Test
+    void chat_missingRequiredFields() throws Exception {
+        ChatRequest request = new ChatRequest();
+        request.setMessage("hello");
+
+        mockMvc.perform(post("/v1/chat")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## Summary
- add POST /v1/chat controller with DTOs, validation, and service logic
- return chat responses with generated session IDs, usage metrics, and latency
- document curl example and add controller tests for success and validation failures

## Testing
- mvn test *(네트워크 문제로 의존성 다운로드 실패)*

------
https://chatgpt.com/codex/tasks/task_e_68d43b7d8ea4832fb79f887c90822c06