### PR TITLE
docs: add comprehensive Korean Javadoc & inline comments (controllers/services/dto/config/frontend/CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI (Build & Unit Test)
 
+# 기본 트리거: main 브랜치 push 및 PR 이벤트에 반응
 on:
   push:
     branches: [ main ]
@@ -26,7 +27,7 @@ jobs:
 
     # (정말 필요한 경우가 아니라면) 전역 모델/키는 CI에 두지 않는 것을 권장
     # env:
-    #   OPENAI_MODEL: gpt-4o-mini
+    #   OPENAI_MODEL: gpt-4o-mini  # 필요 시 여기에서 secrets.OPENAI_API_KEY 등을 주입
 
     steps:
       - name: Checkout
@@ -34,6 +35,7 @@ jobs:
         with:
           fetch-depth: 0  # (선택) 버전/태그 쓸 일 있으면 전체 히스토리
 
+      # Temurin 기반 JDK 17을 설치하고 Maven 캐시 사용
       - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
@@ -44,6 +46,7 @@ jobs:
       - name: Ensure mvnw is executable
         run: chmod +x ./mvnw
 
+      # mvn verify를 실행해 빌드 + 단위 테스트(Surefire) 수행
       - name: Build & Unit Test (Surefire only)
         # ✅ 유닛 테스트만: Failsafe *IT.java는 pom.xml의 <skipITs>true</skipITs> 덕에 스킵됨
         #    유닛에서 OpenAI 호출이 없다면 키 주입도 불필요 → 보안상 더 안전

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,17 +6,18 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 30  # 장시간 실행 방지를 위한 상한 설정
 
     permissions:
       contents: read
 
-    # ✅ secrets를 job env로 먼저 주입
+    # ✅ secrets를 job env로 먼저 주입 (없으면 아래 가드에서 종료)
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       OPENAI_MODEL: gpt-4o-mini
 
     steps:
+      # OPENAI_API_KEY 미설정 시 빠르게 종료해 비용 낭비 방지
       - name: Check secret presence (skip gracefully if missing)
         if: ${{ env.OPENAI_API_KEY == '' }}
         run: |
@@ -37,10 +38,12 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y curl netcat-openbsd
 
+      # 통합 테스트 전 애플리케이션을 빌드 (테스트 스킵)
       - name: Build app (no tests)
         if: ${{ env.OPENAI_API_KEY != '' }}
         run: ./mvnw -B -q -DskipTests clean package
 
+      # 애플리케이션을 백그라운드로 실행하고 헬스체크 성공까지 대기
       - name: Run app in background
         if: ${{ env.OPENAI_API_KEY != '' }}
         run: |
@@ -59,10 +62,12 @@ jobs:
           # 마지막 확인 (실패 시 로그 출력 후 종료)
           curl -fsS http://127.0.0.1:9000/health || (echo "App failed to start"; tail -n 200 app.log; exit 1)
 
+      # Failsafe 기반 E2E 테스트 수행 (-P e2e)
       - name: Run E2E tests (-P e2e)
         if: ${{ env.OPENAI_API_KEY != '' }}
         run: ./mvnw -B -q -P e2e -DskipITs=false verify
 
+      # 실패 시 로그/리포트를 아티팩트로 업로드해 원인 파악
       - name: Upload logs & reports on failure
         if: ${{ failure() && env.OPENAI_API_KEY != '' }}
         uses: actions/upload-artifact@v4
@@ -73,6 +78,7 @@ jobs:
             target/surefire-reports/*
             target/failsafe-reports/*
 
+      # 항상 마지막에 백그라운드 프로세스를 정리
       - name: Stop app
         if: ${{ always() && env.OPENAI_API_KEY != '' }}
         run: |

--- a/frontend/chat.html
+++ b/frontend/chat.html
@@ -1,3 +1,8 @@
+<!--
+  단일 HTML 데모 페이지.
+  API Base와 Bot ID를 입력받아 localStorage에 저장하고, 세션 ID를 유지하며 latency/tokens 지표를 표시한다.
+  브라우저에서 직접 호출하므로 CORS 설정(예: :8000)과 포트 구성을 반드시 확인한다.
+-->
 <!doctype html>
 <html lang="ko">
 <head>
@@ -144,7 +149,7 @@
         localStorage.getItem(LS.botId) ||
         defaultBotId;
 
-    // 세션 유지
+    // 세션 보관: 이전 대화 sessionId를 localStorage에서 복원
     let sessionId = localStorage.getItem(LS.session) || null;
 
     const log = document.getElementById('log');
@@ -218,6 +223,7 @@
         const sendingAt = performance.now();
 
         try {
+            // fetch 호출: 타임아웃 옵션과 JSON 본문을 설정해 API를 직접 호출
             const res = await fetchWithTimeout(url, {
                 method: 'POST',
                 headers: {'Content-Type': 'application/json'},
@@ -238,14 +244,14 @@
             }
 
             const data = await res.json();
-            saveSession(data.sessionId);
+            saveSession(data.sessionId); // 응답 sessionId를 저장해 이후 대화를 이어감
             const latency = typeof data.latencyMs === 'number'
                 ? `${data.latencyMs} ms`
                 : `${Math.round(performance.now() - sendingAt)} ms`;
             const tokens = data.usage
                 ? `tokens p:${data.usage.promptTokens ?? '-'} c:${data.usage.completionTokens ?? '-'}`
                 : '';
-            addBubble('assistant', data.answer || '(응답 없음)', `${latency}${tokens ? ` • ${tokens}` : ''}`);
+            addBubble('assistant', data.answer || '(응답 없음)', `${latency}${tokens ? ` • ${tokens}` : ''}`); // UI 업데이트: 응답/메타 정보 출력
 
         } catch (err) {
             if (err?.name === 'AbortError') {
@@ -255,7 +261,7 @@
             }
         } finally {
             sendBtn.disabled = false;
-            input.focus();
+            input.focus(); // 에러 여부와 관계없이 입력 포커스 복구
         }
     });
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- Spring Boot 기반 Embed Chatbot 애플리케이션 모듈. 기본 JDK 버전은 17을 사용한다. -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -28,7 +29,7 @@
     </properties>
 
     <dependencies>
-        <!-- Web / Validation -->
+        <!-- Web / Validation: REST API 및 Bean Validation 의존성 -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
@@ -38,19 +39,19 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
-        <!-- WebClient (Reactor) -->
+        <!-- WebClient (WebFlux) : 외부 LLM HTTP 호출용 비동기 클라이언트 -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
 
-        <!-- Jackson (명시 유지) -->
+        <!-- Jackson: DTO 직렬화/역직렬화를 명시적으로 유지 -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
-        <!-- Devtools (local only) -->
+        <!-- Devtools: 로컬 개발 시 핫 리로드 지원 -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-devtools</artifactId>
@@ -58,14 +59,14 @@
             <optional>true</optional>
         </dependency>
 
-        <!-- Lombok (optional) -->
+        <!-- Lombok: 선택적 코드 생성 (IDE에서 Annotation Processor 활성화 필요) -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
         </dependency>
 
-        <!-- Test (유닛/슬라이스) -->
+        <!-- Test: 유닛/슬라이스 테스트 번들 -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -75,7 +76,7 @@
 
     <build>
         <plugins>
-            <!-- Compiler (annotation processor: lombok) -->
+            <!-- Compiler: 롬복 Annotation Processor 경로 등록 -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -89,7 +90,7 @@
                 </configuration>
             </plugin>
 
-            <!-- Spring Boot -->
+            <!-- Spring Boot: 실행 가능한 JAR 패키징 -->
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
@@ -103,7 +104,7 @@
                 </configuration>
             </plugin>
 
-            <!-- ✅ 유닛 테스트: Surefire (IT는 여기서 안 돌림) -->
+            <!-- ✅ 유닛 테스트: Surefire (기본 verify 단계에서 실행) -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -114,7 +115,7 @@
                 </configuration>
             </plugin>
 
-            <!-- ✅ 통합(E2E) 테스트: Failsafe (패턴: **/*IT.java) -->
+            <!-- ✅ 통합(E2E) 테스트: Failsafe (패턴: **/*IT.java, -P e2e + -DskipITs=false 시 활성화) -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>

--- a/src/main/java/com/example/embedchatbot/EmbedChatbotApplication.java
+++ b/src/main/java/com/example/embedchatbot/EmbedChatbotApplication.java
@@ -1,11 +1,24 @@
+/*
+ * 애플리케이션 진입점.
+ * 기본 HTTP 포트(9000)와 활성 프로필은 application.yml에서 정의된 값을 따른다.
+ * 부트스트랩 외 다른 책임이 없으며, 실행 옵션은 SpringApplication을 통해 조정한다.
+ */
 package com.example.embedchatbot;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+/**
+ * 스프링 부트 애플리케이션의 엔트리 클래스.
+ * <p>SpringApplication.run(...)을 호출해 내장 서버를 기동하고, 포트/프로필은 설정 파일 및 환경변수로 제어한다.
+ */
 public class EmbedChatbotApplication {
 
+    /**
+     * JVM 진입점으로, 애플리케이션 부팅을 위임한다.
+     * 외부 매개변수는 SpringApplication이 해석하며 별도의 전처리를 수행하지 않는다.
+     */
     public static void main(String[] args) {
         SpringApplication.run(EmbedChatbotApplication.class, args);
     }

--- a/src/main/java/com/example/embedchatbot/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/embedchatbot/config/GlobalExceptionHandler.java
@@ -1,3 +1,8 @@
+/*
+ * 전역 예외 처리기.
+ * REST 컨트롤러 계층에서 발생하는 예외를 표준 응답 형식으로 변환해 API 소비자가 일관된 오류를 받을 수 있도록 한다.
+ * Validation 오류는 400으로, LLM 연동 한도 초과는 429로 매핑하며, 추가 예외는 필요 시 메서드를 확장해 다룬다.
+ */
 package com.example.embedchatbot.config;
 
 import com.example.embedchatbot.service.LlmQuotaExceededException;
@@ -7,9 +12,19 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import java.util.Map;
 
+/**
+ * {@link RestControllerAdvice} 기반으로 API 전체에 적용되는 예외 응답 규약을 정의한다.
+ * <p>Bean Validation 실패는 Spring MVC가 400 응답을 생성하고, LLM 연동 예외는 명시적으로 429로 매핑해 호출자가 재시도 전략을 세우도록 돕는다.</p>
+ */
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    /**
+     * LLM 사용 한도 초과 예외를 429 상태 코드로 매핑한다.
+     * @param ex OpenAI 등 외부 LLM에서 반환한 쿼터 초과 신호
+     * @return HTTP 429와 간결한 오류 메시지를 담은 본문
+     * <p>자세한 원인은 서버 로그에 남기고, 클라이언트에는 민감정보 없이 추상화된 메시지만 전달한다.</p>
+     */
     @ExceptionHandler(LlmQuotaExceededException.class)
     public ResponseEntity<Map<String, Object>> handleQuota(LlmQuotaExceededException ex) {
         return ResponseEntity.status(429).body(Map.of(

--- a/src/main/java/com/example/embedchatbot/config/LlmConfig.java
+++ b/src/main/java/com/example/embedchatbot/config/LlmConfig.java
@@ -1,3 +1,8 @@
+/*
+ * LLM 호출 관련 인프라 구성 빈을 정의한다.
+ * WebClient를 통해 OpenAI 호환 API와 통신하며, 타임아웃/메모리 상한 등 기본 네트워크 정책을 캡슐화한다.
+ * 팀별로 다른 LLM을 쓸 경우 이 설정 클래스를 교체하거나 Bean 이름을 재정의해 확장한다.
+ */
 package com.example.embedchatbot.config;
 
 import org.springframework.beans.factory.annotation.Value;
@@ -10,9 +15,20 @@ import reactor.netty.http.client.HttpClient;
 
 import java.time.Duration;
 
+/**
+ * LLM 연동에 사용할 {@link WebClient} 구성을 제공한다.
+ * <p>기본 base-url과 타임아웃은 application.yml의 app.llm.* 값을 통해 환경별로 오버라이드한다.</p>
+ */
 @Configuration
 public class LlmConfig {
 
+    /**
+     * OpenAI 호환 API 호출용 WebClient Bean을 생성한다.
+     * @param baseUrl 호출 대상 기본 URL (환경변수/프로퍼티로 교체 가능)
+     * @param timeoutMs 응답 대기 타임아웃(ms)
+     * @return LLM API 전용 WebClient 인스턴스
+     * <p>주요 헤더는 서비스 구현체(OpenAiLlmClient)에서 주입하며, 대규모 응답 대비를 위해 in-memory 버퍼 상한을 올려둔다.</p>
+     */
     @Bean
     public WebClient openAiWebClient(
             @Value("${app.llm.base-url}") String baseUrl,

--- a/src/main/java/com/example/embedchatbot/config/WebConfig.java
+++ b/src/main/java/com/example/embedchatbot/config/WebConfig.java
@@ -1,12 +1,26 @@
+/*
+ * 웹 MVC 부가기능 설정.
+ * 현재는 CORS 설정만 담당하며, 프런트엔드 샘플 페이지(frontend/chat.html)에서 호출 시 로컬 개발 포트(8000) 접근을 허용한다.
+ * 운영 환경에서는 허용 오리진을 환경 변수나 별도 프로퍼티로 덮어쓰는 방식을 권장한다.
+ */
 package com.example.embedchatbot.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+/**
+ * MVC 레벨의 교차 출처 제어를 담당한다.
+ * <p>로컬 프런트엔드 개발(기본 8000 포트)과 분리된 운영 도메인을 명시적으로 관리할 수 있도록 구조를 단순화했다.</p>
+ */
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+    /**
+     * 전체 경로에 대해 CORS 허용 오리진을 등록한다.
+     * <p>샘플 HTML은 localhost/127.0.0.1:8000을 기본값으로 사용하므로 해당 포트를 열어둔다.
+     * 운영 시에는 application.yml 또는 별도 설정 클래스로 허용 목록을 분리한다.</p>
+     */
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")

--- a/src/main/java/com/example/embedchatbot/controller/ChatController.java
+++ b/src/main/java/com/example/embedchatbot/controller/ChatController.java
@@ -1,3 +1,8 @@
+/*
+ * 대화 API 컨트롤러 정의.
+ * /v1/chat 엔드포인트를 통해 프런트/백오피스 등 외부 클라이언트가 LLM 대화 요청을 수행한다.
+ * 요청 유효성 검증, 지연시간 측정, 응답 DTO 매핑 책임을 이 계층에서 집중 처리한다.
+ */
 package com.example.embedchatbot.controller;
 
 import com.example.embedchatbot.dto.ChatRequest;
@@ -11,6 +16,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * /v1/chat 엔드포인트 컨트롤러.
+ * <p>요청 유효성 검사 → 서비스 호출 → 응답 포맷 통일 및 지연시간(ms) 산출까지 담당하며,
+ * Validation 오류는 GlobalExceptionHandler와 결합해 400으로 표준화된다.</p>
+ */
 @RestController
 @RequestMapping("/v1/chat")
 public class ChatController {
@@ -21,11 +31,22 @@ public class ChatController {
         this.chatService = chatService;
     }
 
+    /**
+     * 대화 요청을 처리한다.
+     * @param request 필수: botId, message | 선택: sessionId, meta
+     * @return answer, sessionId, usage(prompt/completion 토큰 추정치), latencyMs를 포함한 응답 DTO
+     * @throws org.springframework.web.bind.MethodArgumentNotValidException 유효성 실패 시 발생하며 400으로 매핑된다.
+     * <p>서비스 호출 시간 측정을 위해 ns 단위로 기록 후 ms로 환산한다.</p>
+     */
     @PostMapping
     public ResponseEntity<ChatResponse> chat(@Valid @RequestBody ChatRequest request) {
+        // 서비스 전체 지연 시간을 확인하기 위해 ns 기반 타임스탬프를 기록
         long startTime = System.nanoTime();
+        // 핵심 비즈니스 로직(LLM 호출/폴백)을 수행하고 ChatResult로 전달받음
         ChatResult result = chatService.chat(request);
+        // 호출 종료 시점을 다시 측정해 ms 단위 지연시간을 산출
         long latencyMs = Math.round((System.nanoTime() - startTime) / 1_000_000.0);
+        // 서비스 결과를 API 응답 규격(ChatResponse)으로 변환해 반환
         ChatResponse response = new ChatResponse(result.answer(), result.sessionId(), result.usage(), latencyMs);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/example/embedchatbot/controller/HealthCheckController.java
+++ b/src/main/java/com/example/embedchatbot/controller/HealthCheckController.java
@@ -1,11 +1,24 @@
+/*
+ * 헬스체크 전용 컨트롤러.
+ * ALB, Kubernetes, CI 파이프라인 등 외부 헬스체크가 서비스 생존 여부를 빠르게 판단할 수 있도록 경량 엔드포인트를 제공한다.
+ * 비즈니스 로직과 분리된 단순 문자열 응답을 유지해 장애 시에도 오버헤드를 최소화한다.
+ */
 package com.example.embedchatbot.controller;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+/**
+ * /health 엔드포인트를 노출해 가용성 모니터링을 돕는다.
+ * <p>ALB, GitHub Actions E2E 테스트 등 외부 시스템이 애플리케이션의 readiness를 확인할 때 사용한다.</p>
+ */
 @RestController
 public class HealthCheckController {
 
+    /**
+     * 간단한 문자열 "OK"를 반환해 서비스 정상 동작 여부를 알린다.
+     * <p>복잡한 계산이나 외부 의존성이 없어야 하므로 DB/LLM 호출은 포함하지 않는다.</p>
+     */
     @GetMapping("/health")
     public String health() {
         return "OK";

--- a/src/main/java/com/example/embedchatbot/dto/ChatRequest.java
+++ b/src/main/java/com/example/embedchatbot/dto/ChatRequest.java
@@ -1,19 +1,32 @@
+/*
+ * /v1/chat 요청 페이로드 DTO.
+ * 컨트롤러 계층에서 클라이언트 입력을 검증하고, 서비스로 전달하기 위해 정의되었다.
+ * 필수 필드(botId, message)에는 Bean Validation을 적용해 빠르게 오류를 감지한다.
+ */
 package com.example.embedchatbot.dto;
 
 import jakarta.validation.constraints.NotBlank;
 
 import java.util.Map;
 
+/**
+ * 클라이언트가 LLM 대화를 요청할 때 전달하는 파라미터를 보관한다.
+ * <p>botId와 message는 필수이며, sessionId/meta는 선택값으로 세션 유지/추적에 활용한다.</p>
+ */
 public class ChatRequest {
 
+    /** bot 인스턴스를 식별하는 필수 ID (공백 금지). */
     @NotBlank
     private String botId;
 
+    /** 사용자 프롬프트 본문 (필수, 공백 금지). */
     @NotBlank
     private String message;
 
+    /** 기존 세션을 이어갈 때 사용하는 선택적 세션 ID. */
     private String sessionId;
 
+    /** 대화 메타데이터(추적용 태그, 사용자 속성 등)를 전달하는 선택 맵. */
     private Map<String, Object> meta;
 
     public ChatRequest() {

--- a/src/main/java/com/example/embedchatbot/dto/ChatResponse.java
+++ b/src/main/java/com/example/embedchatbot/dto/ChatResponse.java
@@ -1,10 +1,23 @@
+/*
+ * /v1/chat 응답 DTO.
+ * 서비스에서 생성된 결과를 직렬화하기 위한 읽기 전용 컨테이너로, latency/tokens 정보까지 포함한다.
+ * 컨트롤러에서만 생성하며, 역직렬화 대상이 아니므로 불변 필드를 유지한다.
+ */
 package com.example.embedchatbot.dto;
 
+/**
+ * 대화 응답을 캡슐화하는 읽기 전용 DTO.
+ * <p>클라이언트 표시용 답변 텍스트, 세션 ID, 토큰 추정치, 지연시간(ms)을 모두 전달한다.</p>
+ */
 public class ChatResponse {
 
+    /** 생성된 답변 텍스트. */
     private final String answer;
+    /** 세션 유지를 위한 식별자. */
     private final String sessionId;
+    /** LLM 호출 시 추정된 토큰 소비량. */
     private final ChatUsage usage;
+    /** 서버가 측정한 왕복 지연시간(ms). */
     private final long latencyMs;
 
     public ChatResponse(String answer, String sessionId, ChatUsage usage, long latencyMs) {

--- a/src/main/java/com/example/embedchatbot/dto/ChatResult.java
+++ b/src/main/java/com/example/embedchatbot/dto/ChatResult.java
@@ -1,4 +1,13 @@
+/*
+ * 서비스 내부에서 사용하는 대화 결과 DTO.
+ * LLM 호출 및 폴백 로직에서 생산된 답변/세션/토큰 추정치를 컨트롤러 계층으로 전달한다.
+ * API 응답 직전에 latency 정보만 추가되므로, 이 구조체는 순수 비즈니스 결과만 표현한다.
+ */
 package com.example.embedchatbot.dto;
 
+/**
+ * ChatService가 반환하는 내부용 결과 레코드.
+ * <p>응답 본문, 세션 ID, 토큰 추정치를 포함하며, latency 계산은 컨트롤러에서 추가된다.</p>
+ */
 public record ChatResult(String answer, String sessionId, ChatUsage usage) {
 }

--- a/src/main/java/com/example/embedchatbot/dto/ChatUsage.java
+++ b/src/main/java/com/example/embedchatbot/dto/ChatUsage.java
@@ -1,4 +1,14 @@
+/*
+ * LLM 호출 시 추정된 토큰 사용량 DTO.
+ * 정확한 토크나이저 대신 문자열 길이 기반의 간이 계산 결과를 노출하므로 참고 지표로만 사용한다.
+ */
 package com.example.embedchatbot.dto;
 
-public record ChatUsage(int promptTokens, int completionTokens) {
+/**
+ * 프롬프트/응답 각각의 토큰 추정치를 보관한다.
+ * <p>실제 토큰 수와 오차가 발생할 수 있으므로 과금/정확성 판단 시 주의한다.</p>
+ */
+public record ChatUsage(
+        /** 사용자 입력(prompt)에 해당하는 추정 토큰 수. */ int promptTokens,
+        /** 모델 응답(completion)에 해당하는 추정 토큰 수. */ int completionTokens) {
 }

--- a/src/main/java/com/example/embedchatbot/service/ChatService.java
+++ b/src/main/java/com/example/embedchatbot/service/ChatService.java
@@ -1,3 +1,8 @@
+/*
+ * 대화 비즈니스 로직을 담당하는 서비스.
+ * 세션 ID 생성, LLM 호출/폴백, 토큰 사용량 추정 등 컨트롤러와 LLM 클라이언트 사이의 오케스트레이션을 수행한다.
+ * 장애 시에도 응답성을 유지하기 위해 Echo 폴백 전략을 내장한다.
+ */
 package com.example.embedchatbot.service;
 
 import com.example.embedchatbot.dto.ChatRequest;
@@ -10,6 +15,10 @@ import org.springframework.util.StringUtils;
 
 import java.util.UUID;
 
+/**
+ * 대화 플로우를 총괄하는 서비스 레이어.
+ * <p>세션 ID를 보정하고, LlmClient를 호출해 응답을 생성하며, 실패 시 Echo로 폴백하고 토큰 사용량을 추정한다.</p>
+ */
 @Service
 public class ChatService {
 
@@ -23,6 +32,12 @@ public class ChatService {
         log.info("LLM enabled at startup: {}", llmClient != null && llmClient.enabled());
     }
 
+    /**
+     * LLM 대화 요청을 처리한다.
+     * @param request 클라이언트에서 전달된 필수/선택 파라미터
+     * @return LLM 또는 Echo 폴백으로 생성된 답변과 세션/토큰 정보를 담은 결과 DTO
+     * @throws RuntimeException 하위 LlmClient에서 발생한 예외는 잡아 폴백하지만, 기타 예외는 로깅 후 다시 던질 수 있다.
+     */
     public ChatResult chat(ChatRequest request) {
         final long t0 = System.nanoTime();
         log.debug("chat() called: botId={}, hasSession={}, msgLen={}",
@@ -40,15 +55,17 @@ public class ChatService {
                 answer = llmClient.generate(sys, request.getMessage());
             } else {
                 log.debug("LLM disabled → using Echo fallback (sessionId={})", sessionId);
+                // LLM 비활성 시 가용성을 위해 단순 Echo 응답으로 즉시 폴백
                 answer = buildEcho(request.getMessage());
             }
         } catch (Exception ex) {
-            // ⬇️ 왜 폴백됐는지 원인까지 남김
+            // LLM 실패(네트워크/쿼터/예외 등) 시에도 Echo로 폴백해 응답성을 확보
             log.warn("LLM call failed → Echo fallback. reason={}", ex.toString());
             answer = buildEcho(request.getMessage());
         }
 
         long latencyMs = (System.nanoTime() - t0) / 1_000_000;
+        // 문자열 길이를 기반으로 한 간이 토큰 추정치 (정확한 토크나이저 아님)
         ChatUsage usage = new ChatUsage(estimateTokens(request.getMessage()), estimateTokens(answer));
 
         log.debug("chat() done: sessionId={}, latencyMs={}, promptTok={}, completionTok={}",

--- a/src/main/java/com/example/embedchatbot/service/LlmClient.java
+++ b/src/main/java/com/example/embedchatbot/service/LlmClient.java
@@ -1,6 +1,26 @@
+/*
+ * LLM 호출 계약을 정의하는 인터페이스.
+ * 구현체는 동기 generate() 호출을 제공하며, 향후 스트리밍 API 확장 시 이 인터페이스를 교체/확장한다.
+ */
 package com.example.embedchatbot.service;
 
+/**
+ * LLM 호출 기능의 최소 계약을 정의한다.
+ * <p>현재는 단일 턴 동기 호출만 지원하지만, 추후 스트리밍/멀티턴 지원을 위해 메서드 확장 가능성을 염두에 둔다.</p>
+ */
 public interface LlmClient {
+    /**
+     * 시스템 프롬프트와 사용자 메시지를 전달해 응답을 생성한다.
+     * @param systemPrompt 어시스턴트 기본 지침(없으면 null)
+     * @param userMessage 사용자 입력(필수)
+     * @return LLM이 생성한 텍스트 응답
+     * @throws Exception 네트워크/429/쿼터 초과 등 외부 API 호출 실패 시 발생하며 상위에서 폴백 처리한다.
+     */
     String generate(String systemPrompt, String userMessage) throws Exception;
+
+    /**
+     * 클라이언트가 활성 상태인지 여부를 알려준다.
+     * <p>API 키 미설정 등으로 호출 불가할 때 false를 반환하며, 호출자는 폴백 경로를 준비한다.</p>
+     */
     boolean enabled();
 }

--- a/src/main/java/com/example/embedchatbot/service/LlmQuotaExceededException.java
+++ b/src/main/java/com/example/embedchatbot/service/LlmQuotaExceededException.java
@@ -1,5 +1,13 @@
+/*
+ * LLM 사용 한도 초과를 표현하는 런타임 예외.
+ * 외부 API가 429/insufficient_quota를 반환할 때 발생시켜 상위 계층이 사용자 친화적인 메시지와 적절한 로깅 전략을 적용하도록 돕는다.
+ */
 package com.example.embedchatbot.service;
 
+/**
+ * LLM 쿼터 초과 상황을 표현하는 도메인 예외.
+ * <p>GlobalExceptionHandler가 429 응답으로 매핑하며, 서버 로그에서는 경고 레벨로 기록해 운영자가 모니터링할 수 있게 한다.</p>
+ */
 public class LlmQuotaExceededException extends RuntimeException {
     public LlmQuotaExceededException(String message) { super(message); }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,15 @@
+# 개발 기본값. 운영 환경에서는 환경변수로 오버라이드 권장.
+# OPENAI_API_KEY / OPENAI_MODEL / OPENAI_BASE_URL
+# (IntelliJ: Run/Debug Config → Environment variables에 설정)
 server:
   port: 9000
 app:
   llm:
-    # 환경변수로 덮어쓰기: OPENAI_API_KEY, OPENAI_MODEL, OPENAI_BASE_URL
-    provider: openai
-    model: ${OPENAI_MODEL:gpt-4o-mini}
-    base-url: ${OPENAI_BASE_URL:https://api.openai.com/v1}
-    api-key: ${OPENAI_API_KEY:}
-    timeout-ms: 15000
+    provider: openai              # 사용 중인 LLM 공급자 식별자 (다른 공급자 사용 시 교체)
+    model: ${OPENAI_MODEL:gpt-4o-mini}   # 기본 모델명, 운영은 환경변수 OPENAI_MODEL로 교체 권장
+    base-url: ${OPENAI_BASE_URL:https://api.openai.com/v1}  # API 엔드포인트. 사설 프록시 사용 시 이 값을 변경
+    api-key: ${OPENAI_API_KEY:}   # 인증 토큰. 기본값 없음 → 운영/로컬 실행 시 환경변수로 주입
+    timeout-ms: 15000             # 외부 LLM 응답 대기 타임아웃(ms). 네트워크 품질에 따라 조정
 logging:
   level:
     com.example.embedchatbot: DEBUG     # 우리 코드 전반을 DEBUG로

--- a/src/test/java/com/example/embedchatbot/controller/ChatControllerTest.java
+++ b/src/test/java/com/example/embedchatbot/controller/ChatControllerTest.java
@@ -19,6 +19,10 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+/**
+ * ChatController 슬라이스 테스트.
+ * <p>/v1/chat 엔드포인트가 정상 응답/유효성 검증 오류를 올바르게 처리하는지 검증한다.</p>
+ */
 @WebMvcTest(controllers = ChatController.class)
 class ChatControllerTest {
 
@@ -30,6 +34,7 @@ class ChatControllerTest {
     @DisplayName("POST /v1/chat returns chat response")
     @Test
     void chat_success() throws Exception {
+        // Given
         ChatUsage usage = new ChatUsage(10, 12);
         ChatResult result = new ChatResult("Echo: hello", "session-123", usage);
         given(chatService.chat(any(ChatRequest.class))).willReturn(result);
@@ -38,9 +43,11 @@ class ChatControllerTest {
         request.setBotId("bot-1");
         request.setMessage("hello");
 
+        // When
         mockMvc.perform(post("/v1/chat")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
+                // Then
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.answer", is("Echo: hello")))
                 .andExpect(jsonPath("$.sessionId", is("session-123")))
@@ -52,12 +59,15 @@ class ChatControllerTest {
     @DisplayName("POST /v1/chat validates required fields")
     @Test
     void chat_missingRequiredFields() throws Exception {
-        ChatRequest request = new ChatRequest(); // botId 누락
+        // Given: botId 누락 시 400 반환 보장
+        ChatRequest request = new ChatRequest();
         request.setMessage("hello");
 
+        // When
         mockMvc.perform(post("/v1/chat")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
+                // Then
                 .andExpect(status().isBadRequest());
     }
 }

--- a/src/test/java/com/example/embedchatbot/e2e/E2eChatIT.java
+++ b/src/test/java/com/example/embedchatbot/e2e/E2eChatIT.java
@@ -9,11 +9,16 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * LLM과 실제 통신하는 엔드투엔드 테스트.
+ * <p>실제 서버와 OpenAI 키가 준비된 환경에서 Echo 폴백이 아닌 LLM 응답이 반환되는지 검증한다.</p>
+ */
 @Tag("e2e") // -P e2e에서만 실행
 class E2eChatIT {
 
     @Test
     void chat_should_return_llm_answer_not_echo() {
+        // Given: 서버와 OPENAI_API_KEY가 준비되어 있을 때
         // 전제: 서버가 9000 포트로 떠있고, OPENAI_API_KEY 환경변수가 설정되어 있어야 함
         RestTemplate rt = new RestTemplate();
         String url = "http://127.0.0.1:9000/v1/chat";
@@ -22,8 +27,10 @@ class E2eChatIT {
         var headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
 
+        // When: 실제 REST 호출 수행
         ResponseEntity<Map> res = rt.exchange(url, HttpMethod.POST, new HttpEntity<>(body, headers), Map.class);
 
+        // Then: 200 OK + Echo가 아닌 응답을 확인
         assertThat(res.getStatusCode()).isEqualTo(HttpStatus.OK);
         Object answer = res.getBody().get("answer");
         assertThat(answer).isInstanceOf(String.class);


### PR DESCRIPTION
## Summary
- 컨트롤러, 서비스, DTO, 설정 클래스에 한국어 파일 헤더와 Javadoc을 추가해 LLM 호출 흐름(재시도·폴백 포함)을 문서화했습니다.
- application.yml, frontend/chat.html, Maven/CI 설정에 환경 구성 및 CORS·토큰 추정 관련 주석을 보강했습니다.
- 테스트 코드에 시나리오 Javadoc과 Given/When/Then 주석을 넣어 헬스체크 및 /v1/chat 동작 보장을 명확히 했습니다.

## Files
- src/main/java/com/example/embedchatbot/EmbedChatbotApplication.java
- src/main/java/com/example/embedchatbot/config/*.java
- src/main/java/com/example/embedchatbot/controller/*.java
- src/main/java/com/example/embedchatbot/dto/*.java
- src/main/java/com/example/embedchatbot/service/*.java
- src/main/resources/application.yml
- src/test/java/com/example/embedchatbot/**
- frontend/chat.html
- pom.xml
- .github/workflows/ci.yml
- .github/workflows/e2e.yml

## Testing
- `./mvnw -q clean verify` *(실패 - Maven 배포판 다운로드가 네트워크 제한으로 차단됨)*

------
https://chatgpt.com/codex/tasks/task_e_68d47f274b74832fb746040a521ebb08